### PR TITLE
Removing armeabi-v7a-hard ABI setting as it's deprecated in NDK r12.

### DIFF
--- a/LunarGSamples/API-Samples/android/allocdescriptorsets/build.gradle
+++ b/LunarGSamples/API-Samples/android/allocdescriptorsets/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/build.gradle
+++ b/LunarGSamples/API-Samples/android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle-experimental:0.7.0-beta1'
+        classpath 'com.android.tools.build:gradle-experimental:0.7.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/LunarGSamples/API-Samples/android/copyblitimage/build.gradle
+++ b/LunarGSamples/API-Samples/android/copyblitimage/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/dbgcreatemsgcallback/build.gradle
+++ b/LunarGSamples/API-Samples/android/dbgcreatemsgcallback/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/depthbuffer/build.gradle
+++ b/LunarGSamples/API-Samples/android/depthbuffer/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/descriptor_pipeline_layouts/build.gradle
+++ b/LunarGSamples/API-Samples/android/descriptor_pipeline_layouts/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/device/build.gradle
+++ b/LunarGSamples/API-Samples/android/device/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/drawcube/build.gradle
+++ b/LunarGSamples/API-Samples/android/drawcube/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/drawsubpasses/build.gradle
+++ b/LunarGSamples/API-Samples/android/drawsubpasses/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/drawtexturedcube/build.gradle
+++ b/LunarGSamples/API-Samples/android/drawtexturedcube/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/dynamicuniform/build.gradle
+++ b/LunarGSamples/API-Samples/android/dynamicuniform/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/enable_validation_with_callback/build.gradle
+++ b/LunarGSamples/API-Samples/android/enable_validation_with_callback/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/enumerate-adv/build.gradle
+++ b/LunarGSamples/API-Samples/android/enumerate-adv/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/enumerate/build.gradle
+++ b/LunarGSamples/API-Samples/android/enumerate/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/immutable_sampler/build.gradle
+++ b/LunarGSamples/API-Samples/android/immutable_sampler/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/initcommandbuffer/build.gradle
+++ b/LunarGSamples/API-Samples/android/initcommandbuffer/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/initframebuffers/build.gradle
+++ b/LunarGSamples/API-Samples/android/initframebuffers/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/initpipeline/build.gradle
+++ b/LunarGSamples/API-Samples/android/initpipeline/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/initrenderpass/build.gradle
+++ b/LunarGSamples/API-Samples/android/initrenderpass/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/initshaders/build.gradle
+++ b/LunarGSamples/API-Samples/android/initshaders/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/initswapchain/build.gradle
+++ b/LunarGSamples/API-Samples/android/initswapchain/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/inittexture/build.gradle
+++ b/LunarGSamples/API-Samples/android/inittexture/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/instance/build.gradle
+++ b/LunarGSamples/API-Samples/android/instance/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/instance_extension_properties/build.gradle
+++ b/LunarGSamples/API-Samples/android/instance_extension_properties/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/instance_layer_extension_properties/build.gradle
+++ b/LunarGSamples/API-Samples/android/instance_layer_extension_properties/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/instance_layer_properties/build.gradle
+++ b/LunarGSamples/API-Samples/android/instance_layer_properties/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/multiple_sets/build.gradle
+++ b/LunarGSamples/API-Samples/android/multiple_sets/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/multithreadcmdbuf/build.gradle
+++ b/LunarGSamples/API-Samples/android/multithreadcmdbuf/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/occlusion_query/build.gradle
+++ b/LunarGSamples/API-Samples/android/occlusion_query/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/pipeline_cache/build.gradle
+++ b/LunarGSamples/API-Samples/android/pipeline_cache/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/pipeline_derivative/build.gradle
+++ b/LunarGSamples/API-Samples/android/pipeline_derivative/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/project_template/build.gradle
+++ b/LunarGSamples/API-Samples/android/project_template/build.gradle
@@ -77,15 +77,6 @@ model {
         @OTHER_FLAGS@
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/push_constants/build.gradle
+++ b/LunarGSamples/API-Samples/android/push_constants/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/secondarycmd/build.gradle
+++ b/LunarGSamples/API-Samples/android/secondarycmd/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/separate_image_sampler/build.gradle
+++ b/LunarGSamples/API-Samples/android/separate_image_sampler/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/spirv_assembly/build.gradle
+++ b/LunarGSamples/API-Samples/android/spirv_assembly/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/spirv_specialization/build.gradle
+++ b/LunarGSamples/API-Samples/android/spirv_specialization/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/template/build.gradle
+++ b/LunarGSamples/API-Samples/android/template/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/texelbuffer/build.gradle
+++ b/LunarGSamples/API-Samples/android/texelbuffer/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/uniformbuffer/build.gradle
+++ b/LunarGSamples/API-Samples/android/uniformbuffer/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {

--- a/LunarGSamples/API-Samples/android/vertexbuffer/build.gradle
+++ b/LunarGSamples/API-Samples/android/vertexbuffer/build.gradle
@@ -77,15 +77,6 @@ model {
         
     }
 
-    // Turn on hard float support in armeabi-v7a
-    android.abis {
-        create("armeabi-v7a") {
-            cppFlags.addAll(["-mhard-float", "-D_NDK_MATH_NO_SOFTFP=1", "-mfloat-abi=hard"])
-            ldLibs.add("m_hard")
-            ldFlags.add("-Wl,--no-warn-mismatch")
-        }
-    }
-
     android.sources {
         main {
             jni {


### PR DESCRIPTION
- Remove armeabi-v7a-hard settings in build.gralde
- Update gradle plug in version to 0.7.0

Tested: on OSX, Android Studio 2.2.
