### PR TITLE
Bypass find_package(Threads) for ANDROID in Hologram/CMakeLists.txt

### DIFF
--- a/LunarGSamples/Sample-Programs/Hologram/CMakeLists.txt
+++ b/LunarGSamples/Sample-Programs/Hologram/CMakeLists.txt
@@ -1,5 +1,8 @@
 find_package(PythonInterp 3 REQUIRED)
-find_package(Threads REQUIRED)
+
+if(NOT ANDROID)
+    find_package(Threads REQUIRED)
+endif()
 
 macro(generate_dispatch_table out)
     add_custom_command(OUTPUT ${out}


### PR DESCRIPTION
it is not needed to generate Android build scripts, to avoid error
on Windows+ANDROID
@qchong, @hak, Please Take A Look, thanks